### PR TITLE
bug: 카카오 페이 승인 버그 수정 #80

### DIFF
--- a/src/main/java/project/finalproject1backend/service/payment/KakaoPayService.java
+++ b/src/main/java/project/finalproject1backend/service/payment/KakaoPayService.java
@@ -36,11 +36,18 @@ public class KakaoPayService {
         // 카카오페이 요청 양식
         MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
 
-        Orders order = this.getOrdersByPartnerOrderId(requsetDTO.getPartner_order_id());
+        String partner_order_id = requsetDTO.getPartner_order_id();
+        Orders order = this.getOrdersByPartnerOrderId(partner_order_id);
+
+        // 입력 받은 금액과 DB 금액이 비교
+        int dbAmount = order.getTotalPrice();
+        if (dbAmount != requsetDTO.getTotal_amount()) {
+            throw new PaymentException();
+        }
 
         // 서버와 주고 받을 정보
         parameters.add("cid", cid);
-        parameters.add("partner_order_id", String.valueOf(order.getNumber()));
+        parameters.add("partner_order_id", partner_order_id);
         parameters.add("partner_user_id", order.getUser().getEmail());
         parameters.add("total_amount", String.valueOf(order.getTotalPrice()));
 
@@ -53,7 +60,8 @@ public class KakaoPayService {
 //        parameters.add("vat_amount", "0"); // 상품 부가세 금액 필수 아님, 없으면 0 설정
         
         // TODO: 2023-05-12 url 잘 작동하는 지 확인 필요
-        parameters.add("approval_url", "http://52.78.88.121:8080/account/pay/kakao/success"); // 성공 시 redirect url
+        parameters.add("approval_url", "http://52.78.88.121:8080/account/pay/kakao/success?partner_order_id=" +
+                partner_order_id); // 성공 시 redirect url, 주문 번호 쿼리 스트링 추가
         parameters.add("cancel_url", "http://52.78.88.121:8080/account/pay/kakao/cancel"); // 취소 시 redirect url
         parameters.add("fail_url", "http://52.78.88.121:8080/account/pay/kakao/fail"); // 실패 시 redirect url
 


### PR DESCRIPTION
카카오 페이 승인 단계에서 주문 번호가 쿼리 스트링으로 전달되지 않는 버그를 수정함

## PR Type

What kind of change does this PR introduce?

<!-- 'x'를 이용하여 이 PR에 적용되는 항목을 확인해 주세요. -->

- [x] 버그를 수정했어요.
- [ ] 새로운 기능을 추가했어요.
- [ ] 코드 스타일 업데이트를 했어요(포맷팅, 지역변수)
- [ ] 리팩토링을 했어요 (기능적인 변화 없이, api 변경 없이)
- [ ] 환경설정을 변경했어요.
- [ ] 문서 내용을 변경했어요.
- [ ] 기타 사항을 설명해 주세요.

## Related Issues

<!--#을 눌러 이슈와 연결해 주세요-->

## What does this PR do?

#80 

<!--무엇을 하셨나요?-->

- [ ] 카카오 페이 승인 url에 쿼리 스트링 추가

## Other information

[카카오 페이 문의 답변](https://devtalk.kakao.com/t/topic/107721?u=kakaopay_pg)
